### PR TITLE
80 use updownload artifact instead of js script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,12 @@ jobs:
           sha256sum devcon-* > checksums.txt
           cat checksums.txt
 
+      - name: Upload checksums artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: checksums
+          path: checksums.txt
+
       - name: Upload checksums
         uses: actions/upload-release-asset@v1
         env:
@@ -220,24 +226,9 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Download checksums
-        uses: actions/github-script@v7
+        uses: actions/download-artifact@v8
         with:
-          script: |
-            const fs = require('fs');
-            const { owner, repo } = context.repo;
-            const release = await github.rest.repos.getRelease({
-              owner,
-              repo,
-              release_id: context.payload.release.id,
-            });
-            const asset = release.data.assets.find(a => a.name === 'checksums.txt');
-            const response = await github.rest.repos.getReleaseAsset({
-              owner,
-              repo,
-              asset_id: asset.id,
-              headers: { Accept: 'application/octet-stream' },
-            });
-            fs.writeFileSync('checksums.txt', Buffer.from(response.data));
+          name: checksums
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@v4


### PR DESCRIPTION
- **feat: log output of stderr in exec command**
- **fix: marker files created with sudo to bypass permission problems**
- **fix: piping in docker command is necessary for shell**
- **feat: add ssh server proxy wrapper**
- **fix: clippy warnings in new file**
- **fix: ignore unupdateable crate**
- **feat: extract user info from image**
- **chore: update version of dependency**
- **chore: update dependencies**
- **fix: use correct piping of command in container environment**
- **docs: updated readme [skip-ci]**
- **chore: bump application version**
- **ci: use upload-artifact and download-artifact actions for checksums**
