### PR TITLE
Container lifecycle improvements

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -763,13 +763,14 @@ pub fn handle_up_command(
     // Process features once
     let (processed_features, _) = driver.prepare_features(&devcontainer_workspace)?;
 
-    // Only build if the image does not already exist. Docker rebuilding the same Dockerfile
-    // always produces a new image ID (the manifest includes a created timestamp), which would
-    // cause `start_with_features` to treat the existing container as stale and create a new
-    // one on every `devcon up` — the bug reported in #85.  When the image is already present
-    // the existing container remains current and is reused.
-    if driver.image_exists(&devcontainer_workspace)? {
-        debug!("Image already exists, skipping build");
+    // Only build if the config has changed or the image does not yet exist.
+    // Docker rebuilding the same Dockerfile always produces a new image ID (the manifest includes
+    // a created timestamp), which would cause `start_with_features` to treat the existing
+    // container as stale and create a new one on every `devcon up` — the bug reported in #85.
+    // The config hash (stored as a LABEL on the image) detects genuine changes while keeping
+    // the no-op fast-path when nothing has changed.
+    if driver.image_is_current(&devcontainer_workspace)? {
+        debug!("Config hash unchanged, skipping build");
     } else {
         driver.build_with_features(
             devcontainer_workspace.clone(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -736,7 +736,7 @@ pub fn handle_ssh_command(
 /// # use devcon::command::handle_up_command;
 ///
 /// let project_path = PathBuf::from("/path/to/project");
-/// handle_up_command(project_path, None, None, devcon::output::OutputFormat::Text)?;
+/// handle_up_command(project_path, None, None, devcon::output::OutputFormat::Text, false)?;
 /// # Ok::<(), devcon::error::Error>(())
 /// ```
 pub fn handle_up_command(
@@ -744,6 +744,7 @@ pub fn handle_up_command(
     build_path: Option<PathBuf>,
     config_path: Option<PathBuf>,
     output: OutputFormat,
+    force_rebuild: bool,
 ) -> Result<()> {
     warn_if_serve_not_running();
     let config = Config::load(config_path)?;
@@ -763,15 +764,19 @@ pub fn handle_up_command(
     // Process features once
     let (processed_features, _) = driver.prepare_features(&devcontainer_workspace)?;
 
-    // Only build if the config has changed or the image does not yet exist.
+    // Only build if the config has changed, the image does not yet exist, or a force rebuild
+    // was requested.
     // Docker rebuilding the same Dockerfile always produces a new image ID (the manifest includes
     // a created timestamp), which would cause `start_with_features` to treat the existing
     // container as stale and create a new one on every `devcon up` — the bug reported in #85.
     // The config hash (stored as a LABEL on the image) detects genuine changes while keeping
     // the no-op fast-path when nothing has changed.
-    if driver.image_is_current(&devcontainer_workspace)? {
+    if !force_rebuild && driver.image_is_current(&devcontainer_workspace)? {
         debug!("Config hash unchanged, skipping build");
     } else {
+        if force_rebuild {
+            debug!("Force rebuild requested, rebuilding image");
+        }
         driver.build_with_features(
             devcontainer_workspace.clone(),
             &[],

--- a/src/command.rs
+++ b/src/command.rs
@@ -763,13 +763,21 @@ pub fn handle_up_command(
     // Process features once
     let (processed_features, _) = driver.prepare_features(&devcontainer_workspace)?;
 
-    // Build with pre-processed features
-    driver.build_with_features(
-        devcontainer_workspace.clone(),
-        &[],
-        Some(processed_features.clone()),
-        effective_build_path,
-    )?;
+    // Only build if the image does not already exist. Docker rebuilding the same Dockerfile
+    // always produces a new image ID (the manifest includes a created timestamp), which would
+    // cause `start_with_features` to treat the existing container as stale and create a new
+    // one on every `devcon up` — the bug reported in #85.  When the image is already present
+    // the existing container remains current and is reused.
+    if driver.image_exists(&devcontainer_workspace)? {
+        debug!("Image already exists, skipping build");
+    } else {
+        driver.build_with_features(
+            devcontainer_workspace.clone(),
+            &[],
+            Some(processed_features.clone()),
+            effective_build_path,
+        )?;
+    }
 
     // Start the container with pre-processed features
     let container_id =

--- a/src/driver/container.rs
+++ b/src/driver/container.rs
@@ -497,8 +497,14 @@ impl ContainerDriver {
         self.build_with_features(devcontainer_workspace, env_variables, None, build_path)
     }
 
+    /// Returns `true` if the latest image for the given workspace already exists in the runtime.
+    pub fn image_exists(&self, devcontainer_workspace: &Workspace) -> Result<bool> {
+        let latest_tag = format!("{}:latest", self.get_image_tag(devcontainer_workspace));
+        let images = self.runtime.images()?;
+        Ok(images.iter().any(|image| image == &latest_tag))
+    }
+
     /// Builds a container image with optional pre-processed features.
-    ///
     /// This is the internal implementation that allows reusing already-processed
     /// features to avoid redundant processing.
     ///
@@ -940,6 +946,34 @@ CMD ["-c", "echo Container started\ntrap \"exit 0\" 15\n\nexec \"$@\"\nwhile sle
             info!(
                 "Running container uses a stale image ({}), starting new container with latest",
                 running_image
+            );
+        }
+
+        // Check for a stopped container that already uses the current image.
+        // list() only returns running containers; list_all() includes stopped ones.
+        let all_handles = self.runtime.list_all()?;
+        let stopped_handle = all_handles
+            .iter()
+            .find(|(name, _, _)| name == &container_name);
+
+        if let Some((_, stopped_image, handle)) = stopped_handle {
+            let latest_id = self.runtime.image_id(&latest_tag).unwrap_or(None);
+            let stopped_id = self.runtime.image_id(stopped_image).unwrap_or(None);
+
+            let is_current = match (&latest_id, &stopped_id) {
+                (Some(l), Some(r)) => l == r,
+                _ => stopped_image == &latest_tag,
+            };
+
+            if is_current {
+                info!("Restarting stopped container with latest image");
+                let restarted = self.runtime.start_container(handle.id())?;
+                return Ok(restarted.id().to_string());
+            }
+
+            debug!(
+                "Stopped container uses a stale image ({}), creating new container with latest",
+                stopped_image
             );
         }
 

--- a/src/driver/container.rs
+++ b/src/driver/container.rs
@@ -726,6 +726,7 @@ ENV _CONTAINER_USER={{ container_user }}
 ENV _REMOTE_USER_HOME={{ remote_user_home }}
 ENV _CONTAINER_USER_HOME={{ container_user_home }}
 ENV DEVCON_CONTROL_HOST={{ runtime_host_address }}
+LABEL devcon.config-hash={{ config_hash }}
 
 USER root
 RUN mkdir /tmp/features
@@ -743,6 +744,8 @@ CMD ["-c", "echo Container started\ntrap \"exit 0\" 15\n\nexec \"$@\"\nwhile sle
 "#,
         )?;
 
+        let config_hash = self.get_devcontainer_id(&devcontainer_workspace);
+
         let contents = template.render(minijinja::context! {
             image => &base_image,
             remote_user => &resolved_users.remote_user,
@@ -754,6 +757,7 @@ CMD ["-c", "echo Container started\ntrap \"exit 0\" 15\n\nexec \"$@\"\nwhile sle
             env_setup => &env_setup,
             workspace_name => devcontainer_workspace.path.file_name().unwrap().to_string_lossy(),
             runtime_host_address => self.runtime.get_host_address(),
+            config_hash => &config_hash,
         })?;
 
         fs::write(&dockerfile, contents)?;
@@ -1744,7 +1748,6 @@ CMD ["-c", "echo Container started\ntrap \"exit 0\" 15\n\nexec \"$@\"\nwhile sle
 
         match fs::read_to_string(&devcontainer_path) {
             Ok(content) => {
-                // Hash the file content for configuration-specific ID
                 hasher.update(content.as_bytes());
             }
             Err(_) => {
@@ -1753,8 +1756,56 @@ CMD ["-c", "echo Container started\ntrap \"exit 0\" 15\n\nexec \"$@\"\nwhile sle
             }
         }
 
+        // Also hash the Dockerfile when a build config references one, so that
+        // changes to the Dockerfile trigger a rebuild even if devcontainer.json
+        // is unchanged.
+        if let Some(build_config) = &devcontainer_workspace.devcontainer.build {
+            if build_config.dockerfile.is_some() {
+                let devcontainer_dir = if devcontainer_path.exists() {
+                    devcontainer_path
+                        .parent()
+                        .unwrap_or(&devcontainer_workspace.path)
+                        .to_path_buf()
+                } else {
+                    devcontainer_workspace.path.clone()
+                };
+                let dockerfile_path = resolve_dockerfile_path(build_config, &devcontainer_dir);
+                if let Ok(df_content) = fs::read_to_string(&dockerfile_path) {
+                    hasher.update(df_content.as_bytes());
+                }
+            }
+
+            // Hash build args (sorted for determinism) so arg changes invalidate the cache.
+            if let Some(args) = &build_config.args {
+                let mut sorted_args: Vec<(&String, &String)> = args.iter().collect();
+                sorted_args.sort_by_key(|(k, _)| *k);
+                for (k, v) in sorted_args {
+                    hasher.update(format!("{}={}", k, v).as_bytes());
+                }
+            }
+        }
+
         let result = hasher.finalize();
         format!("{:x}", result)
+    }
+
+    /// Returns `true` when the existing image's config hash matches the current workspace config.
+    ///
+    /// The hash is stored as the `devcon.config-hash` image label at build time. If the image is
+    /// absent or the label is missing (e.g. an image built by an older version of devcon), this
+    /// method returns `false` so that a rebuild is triggered.
+    pub fn image_is_current(&self, devcontainer_workspace: &Workspace) -> Result<bool> {
+        let latest_tag = format!("{}:latest", self.get_image_tag(devcontainer_workspace));
+        let stored = self
+            .runtime
+            .image_label(&latest_tag, "devcon.config-hash")?;
+        match stored {
+            None => Ok(false),
+            Some(stored_hash) => {
+                let current_hash = self.get_devcontainer_id(devcontainer_workspace);
+                Ok(stored_hash == current_hash)
+            }
+        }
     }
 
     fn user_home(user: &str) -> String {

--- a/src/driver/runtime.rs
+++ b/src/driver/runtime.rs
@@ -327,6 +327,34 @@ pub trait ContainerRuntime: Send {
     #[allow(clippy::type_complexity)]
     fn list(&self) -> Result<Vec<(String, String, Box<dyn ContainerHandle>)>>;
 
+    /// Lists all containers including stopped ones.
+    ///
+    /// # Returns
+    ///
+    /// A vector of tuples containing (container_name, image_tag, handle) triples for
+    /// all devcon-managed containers regardless of their state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the list command fails or output cannot be parsed.
+    #[allow(clippy::type_complexity)]
+    fn list_all(&self) -> Result<Vec<(String, String, Box<dyn ContainerHandle>)>>;
+
+    /// Starts a previously stopped container.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_id` - The ID of the stopped container to start
+    ///
+    /// # Returns
+    ///
+    /// A handle to the now-running container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the start command fails.
+    fn start_container(&self, container_id: &str) -> Result<Box<dyn ContainerHandle>>;
+
     /// List images.
     ///
     /// # Returns

--- a/src/driver/runtime.rs
+++ b/src/driver/runtime.rs
@@ -392,6 +392,19 @@ pub trait ContainerRuntime: Send {
     /// `Ok(Some(metadata))` if inspect succeeds, `Ok(None)` if the image does not exist.
     fn inspect_image(&self, image_tag: &str) -> Result<Option<serde_json::Value>>;
 
+    /// Read a single label from an image's metadata.
+    ///
+    /// # Arguments
+    ///
+    /// * `image_tag` - The image tag to inspect (e.g. "devcon-myproject:latest")
+    /// * `label_key` - The label key to look up (e.g. "devcon.config-hash")
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(value))` if the label exists, `Ok(None)` if the image is absent or the label
+    /// is not set.
+    fn image_label(&self, image_tag: &str, label_key: &str) -> Result<Option<String>>;
+
     /// Get the host address for the runtime.
     ///
     /// This is used to configure containers to connect back to the host.

--- a/src/driver/runtime/apple.rs
+++ b/src/driver/runtime/apple.rs
@@ -245,6 +245,70 @@ impl AppleRuntime {
 
         None
     }
+
+    /// Shared implementation for `list` and `list_all`.
+    ///
+    /// When `all` is `true`, stopped/exited containers are included in addition to
+    /// running ones.
+    #[allow(clippy::type_complexity)]
+    fn list_containers(
+        &self,
+        all: bool,
+    ) -> Result<Vec<(String, String, Box<dyn super::ContainerHandle>)>> {
+        let output = Command::new("container")
+            .arg("list")
+            .arg("--format")
+            .arg("json")
+            .output()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let containers: Vec<serde_json::Value> = serde_json::from_str(&stdout)?;
+
+        let result: Vec<(String, String, Box<dyn super::ContainerHandle>)> = containers
+            .iter()
+            .filter_map(|container| {
+                trace!("Inspecting container: {}", container);
+
+                let state = container["status"].as_str().unwrap_or_default();
+                if !all && state != "running" {
+                    return None;
+                }
+
+                let project_name = container["configuration"]["labels"]["devcon.project"]
+                    .as_str()
+                    .unwrap_or_default();
+
+                trace!("Container project name: {}", project_name);
+                if project_name.is_empty() {
+                    return None;
+                }
+
+                let id = container["configuration"]["id"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+
+                debug!("Found container with ID: {}", id);
+
+                let image_tag = container["configuration"]["image"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+
+                let container_name = format!("devcon.{}", project_name);
+                let handle = AppleContainerHandle { id };
+                Some((
+                    container_name,
+                    image_tag,
+                    Box::new(handle) as Box<dyn super::ContainerHandle>,
+                ))
+            })
+            .collect();
+
+        Ok(result)
+    }
 }
 
 impl ContainerRuntime for AppleRuntime {
@@ -487,61 +551,32 @@ impl ContainerRuntime for AppleRuntime {
     }
 
     fn list(&self) -> Result<Vec<(String, String, Box<dyn super::ContainerHandle>)>> {
+        self.list_containers(false)
+    }
+
+    fn list_all(&self) -> Result<Vec<(String, String, Box<dyn super::ContainerHandle>)>> {
+        self.list_containers(true)
+    }
+
+    fn start_container(
+        &self,
+        container_id: &str,
+    ) -> Result<Box<dyn super::ContainerHandle>> {
         let output = Command::new("container")
-            .arg("list")
-            .arg("--format")
-            .arg("json")
+            .arg("start")
+            .arg(container_id)
             .output()?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !output.status.success() {
+            return Err(Error::runtime(format!(
+                "container start failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
 
-        let containers: Vec<serde_json::Value> = serde_json::from_str(&stdout)?;
-
-        let result: Vec<(String, String, Box<dyn super::ContainerHandle>)> = containers
-            .iter()
-            .filter_map(|container| {
-                trace!("Inspecting container: {}", container);
-
-                // Only include running containers (matching Docker runtime behavior)
-                let state = container["status"].as_str().unwrap_or_default();
-                if state != "running" {
-                    return None;
-                }
-
-                let project_name = container["configuration"]["labels"]["devcon.project"]
-                    .as_str()
-                    .unwrap_or_default();
-
-                trace!("Container project name: {}", project_name);
-                if project_name.is_empty() {
-                    return None;
-                }
-
-                let id = container["configuration"]["id"]
-                    .as_str()
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-
-                debug!("Found container with ID: {}", id);
-
-                let image_tag = container["configuration"]["image"]
-                    .as_str()
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-
-                let container_name = format!("devcon.{}", project_name);
-                let handle = AppleContainerHandle { id };
-                Some((
-                    container_name,
-                    image_tag,
-                    Box::new(handle) as Box<dyn super::ContainerHandle>,
-                ))
-            })
-            .collect();
-
-        Ok(result)
+        Ok(Box::new(AppleContainerHandle {
+            id: container_id.to_string(),
+        }))
     }
 
     fn images(&self) -> Result<Vec<String>> {

--- a/src/driver/runtime/apple.rs
+++ b/src/driver/runtime/apple.rs
@@ -688,6 +688,19 @@ impl ContainerRuntime for AppleRuntime {
         Ok(Some(inspect))
     }
 
+    fn image_label(&self, image_tag: &str, label_key: &str) -> Result<Option<String>> {
+        let inspect = self.inspect_image(image_tag)?;
+        // Apple's inspect JSON uses both lowercase and Docker-style key names.
+        let value = inspect
+            .as_ref()
+            .and_then(|v| v.get("Config").or_else(|| v.get("config")))
+            .and_then(|v| v.get("Labels").or_else(|| v.get("labels")))
+            .and_then(|v| v.get(label_key))
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string);
+        Ok(value)
+    }
+
     fn get_host_address(&self) -> String {
         "host.container.internal".to_string()
     }

--- a/src/driver/runtime/apple.rs
+++ b/src/driver/runtime/apple.rs
@@ -558,10 +558,7 @@ impl ContainerRuntime for AppleRuntime {
         self.list_containers(true)
     }
 
-    fn start_container(
-        &self,
-        container_id: &str,
-    ) -> Result<Box<dyn super::ContainerHandle>> {
+    fn start_container(&self, container_id: &str) -> Result<Box<dyn super::ContainerHandle>> {
         let output = Command::new("container")
             .arg("start")
             .arg(container_id)

--- a/src/driver/runtime/docker.rs
+++ b/src/driver/runtime/docker.rs
@@ -537,10 +537,7 @@ impl ContainerRuntime for DockerRuntime {
         self.list_containers(true)
     }
 
-    fn start_container(
-        &self,
-        container_id: &str,
-    ) -> Result<Box<dyn super::ContainerHandle>> {
+    fn start_container(&self, container_id: &str) -> Result<Box<dyn super::ContainerHandle>> {
         let output = Command::new("docker")
             .arg("start")
             .arg(container_id)

--- a/src/driver/runtime/docker.rs
+++ b/src/driver/runtime/docker.rs
@@ -663,6 +663,18 @@ impl ContainerRuntime for DockerRuntime {
         Ok(Some(inspect))
     }
 
+    fn image_label(&self, image_tag: &str, label_key: &str) -> Result<Option<String>> {
+        let inspect = self.inspect_image(image_tag)?;
+        let value = inspect
+            .as_ref()
+            .and_then(|v| v.get("Config"))
+            .and_then(|v| v.get("Labels"))
+            .and_then(|v| v.get(label_key))
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string);
+        Ok(value)
+    }
+
     fn get_host_address(&self) -> String {
         "host.docker.internal".to_string()
     }

--- a/src/driver/runtime/docker.rs
+++ b/src/driver/runtime/docker.rs
@@ -219,6 +219,70 @@ impl DockerRuntime {
 
         None
     }
+
+    /// Shared implementation for `list` and `list_all`.
+    ///
+    /// When `all` is `true`, stopped containers are included (equivalent to `docker ps -a`).
+    #[allow(clippy::type_complexity)]
+    fn list_containers(
+        &self,
+        all: bool,
+    ) -> Result<Vec<(String, String, Box<dyn super::ContainerHandle>)>> {
+        let mut cmd = Command::new("docker");
+        cmd.arg("ps")
+            .arg("--no-trunc")
+            .arg("--filter")
+            .arg("label=devcon.project")
+            .arg("--format")
+            .arg("{{json .}}");
+
+        if all {
+            cmd.arg("--all");
+        }
+
+        let output = cmd.output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut result: Vec<(String, String, Box<dyn super::ContainerHandle>)> = Vec::new();
+
+        for line in stdout.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let container: serde_json::Value = serde_json::from_str(line)?;
+
+            // Labels format: "key1=value1,key2=value2"
+            let labels = container["Labels"].as_str().unwrap_or_default();
+            let mut container_name = String::new();
+            for label_pair in labels.split(',') {
+                if let Some((key, value)) = label_pair.split_once('=')
+                    && key == "devcon.project"
+                {
+                    container_name = format!("devcon.{}", value);
+                    break;
+                }
+            }
+
+            let id = container["ID"]
+                .as_str()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+
+            let image_tag = container["Image"]
+                .as_str()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+
+            if !container_name.is_empty() {
+                let handle = DockerContainerHandle { id: id.clone() };
+                result.push((container_name, image_tag, Box::new(handle)));
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 /// Handle for a Docker container instance.
@@ -466,59 +530,32 @@ impl ContainerRuntime for DockerRuntime {
     }
 
     fn list(&self) -> Result<Vec<(String, String, Box<dyn super::ContainerHandle>)>> {
+        self.list_containers(false)
+    }
+
+    fn list_all(&self) -> Result<Vec<(String, String, Box<dyn super::ContainerHandle>)>> {
+        self.list_containers(true)
+    }
+
+    fn start_container(
+        &self,
+        container_id: &str,
+    ) -> Result<Box<dyn super::ContainerHandle>> {
         let output = Command::new("docker")
-            .arg("ps")
-            .arg("--filter")
-            .arg("label=devcon.project")
-            .arg("--format")
-            .arg("{{json .}}")
+            .arg("start")
+            .arg(container_id)
             .output()?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        let mut result: Vec<(String, String, Box<dyn super::ContainerHandle>)> = Vec::new();
-
-        // Docker outputs one JSON object per line, not an array
-        for line in stdout.lines() {
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let container: serde_json::Value = serde_json::from_str(line)?;
-
-            // Parse labels to find devcon.project label value
-            let labels = container["Labels"].as_str().unwrap_or_default();
-            let mut container_name = String::new();
-
-            // Labels format: "key1=value1,key2=value2"
-            for label_pair in labels.split(',') {
-                if let Some((key, value)) = label_pair.split_once('=')
-                    && key == "devcon.project"
-                {
-                    container_name = format!("devcon.{}", value);
-                    break;
-                }
-            }
-
-            let id = container["ID"]
-                .as_str()
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-
-            let image_tag = container["Image"]
-                .as_str()
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-
-            if !container_name.is_empty() {
-                let handle = DockerContainerHandle { id: id.clone() };
-                result.push((container_name, image_tag, Box::new(handle)));
-            }
+        if !output.status.success() {
+            return Err(Error::runtime(format!(
+                "docker start failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
         }
 
-        Ok(result)
+        Ok(Box::new(DockerContainerHandle {
+            id: container_id.to_string(),
+        }))
     }
 
     fn images(&self) -> Result<Vec<String>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,10 @@ enum Commands {
         /// Path to the build directory.
         #[arg(short, long, help = "Path to the build directory.")]
         build_path: Option<PathBuf>,
+
+        /// Force a rebuild even if the config hash is unchanged.
+        #[arg(long, help = "Force a rebuild, ignoring the cached image.")]
+        force_rebuild: bool,
     },
     /// Execs a shell in a development container for the specified path
     #[command(about = "Exec a shell in a development container with the devcontainer CLI")]
@@ -282,12 +286,17 @@ fn main() -> devcon::error::Result<()> {
                 output,
             )?;
         }
-        Commands::Up { path, build_path } => {
+        Commands::Up {
+            path,
+            build_path,
+            force_rebuild,
+        } => {
             handle_up_command(
                 path.clone().unwrap_or(PathBuf::from(".").to_path_buf()),
                 build_path.clone(),
                 config_path,
                 output,
+                *force_rebuild,
             )?;
         }
         Commands::Shell { path, env } => {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -524,6 +524,85 @@ fn test_up_does_not_rebuild_existing_image() {
 }
 
 #[test]
+fn test_up_rebuilds_when_config_changes() {
+    let runtime = get_runtime();
+    if !is_runtime_available(runtime) {
+        println!("Skipping test: {:?} runtime not available", runtime);
+        return;
+    }
+
+    let test_config = create_test_config();
+    cleanup_test_artifacts(runtime, "test-rebuild-on-change");
+    let temp_dir = create_test_devcontainer(
+        "test-rebuild-on-change",
+        "mcr.microsoft.com/devcontainers/base:ubuntu",
+        None,
+    );
+
+    // First `up` — builds the image with the initial config hash label.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("up")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute first up command");
+    let output = result.unwrap();
+    assert!(
+        output.status.success(),
+        "First up command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let image_id_after_first_up = get_image_id(runtime, "devcon-test-rebuild-on-change:latest")
+        .expect("Image not found after first up");
+
+    // Mutate devcontainer.json so the config hash changes.
+    let devcontainer_path = temp_dir
+        .path()
+        .join(".devcontainer")
+        .join("devcontainer.json");
+    std::fs::write(
+        &devcontainer_path,
+        r#"{
+    "name": "test-rebuild-on-change",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "remoteEnv": { "DEVCON_TEST_CHANGE": "1" }
+}"#,
+    )
+    .expect("Failed to update devcontainer.json");
+
+    // Second `up` — config changed, must rebuild the image.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("up")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute second up command");
+    let output = result.unwrap();
+    assert!(
+        output.status.success(),
+        "Second up command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let image_id_after_second_up = get_image_id(runtime, "devcon-test-rebuild-on-change:latest")
+        .expect("Image not found after second up");
+
+    assert_ne!(
+        image_id_after_first_up, image_id_after_second_up,
+        "Image was NOT rebuilt after devcontainer.json changed"
+    );
+
+    drop(temp_dir);
+}
+
+#[test]
 #[cfg(target_os = "macos")]
 fn test_build_apple_runtime() {
     let runtime = Runtime::Apple;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -603,6 +603,71 @@ fn test_up_rebuilds_when_config_changes() {
 }
 
 #[test]
+fn test_up_force_rebuild() {
+    let runtime = get_runtime();
+    if !is_runtime_available(runtime) {
+        println!("Skipping test: {:?} runtime not available", runtime);
+        return;
+    }
+
+    let test_config = create_test_config();
+    cleanup_test_artifacts(runtime, "test-force-rebuild");
+    let temp_dir = create_test_devcontainer(
+        "test-force-rebuild",
+        "mcr.microsoft.com/devcontainers/base:ubuntu",
+        None,
+    );
+
+    // First `up` — builds the image normally.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("up")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute first up command");
+    let output = result.unwrap();
+    assert!(
+        output.status.success(),
+        "First up command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let image_id_after_first_up = get_image_id(runtime, "devcon-test-force-rebuild:latest")
+        .expect("Image not found after first up");
+
+    // Second `up` with --force-rebuild — config is unchanged, but must rebuild anyway.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("up")
+        .arg("--force-rebuild")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute second up command");
+    let output = result.unwrap();
+    assert!(
+        output.status.success(),
+        "Second up command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let image_id_after_force_rebuild = get_image_id(runtime, "devcon-test-force-rebuild:latest")
+        .expect("Image not found after force rebuild");
+
+    assert_ne!(
+        image_id_after_first_up, image_id_after_force_rebuild,
+        "Image was NOT rebuilt when --force-rebuild was passed"
+    );
+
+    drop(temp_dir);
+}
+
+#[test]
 #[cfg(target_os = "macos")]
 fn test_build_apple_runtime() {
     let runtime = Runtime::Apple;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -438,8 +438,8 @@ fn test_start_reuses_stopped_container() {
         stderr
     );
 
-    let start_json = serde_json::from_str::<serde_json::Value>(&stdout)
-        .expect("start output is not valid JSON");
+    let start_json =
+        serde_json::from_str::<serde_json::Value>(&stdout).expect("start output is not valid JSON");
     let container_id_after_start = start_json["container_id"]
         .as_str()
         .expect("start output JSON does not contain container_id")

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -153,6 +153,7 @@ fn test_build_with_dockerfile() {
         println!("Skipping test: {:?} runtime not available", runtime);
         return;
     }
+    cleanup_test_artifacts(runtime, "test-dockerfile");
     let test_config = create_test_config();
 
     let dockerfile_content = r#"FROM mcr.microsoft.com/devcontainers/base:ubuntu
@@ -305,6 +306,7 @@ fn test_up_microsoft_devcontainer_base_resolves_remote_user() {
         return;
     }
 
+    cleanup_test_artifacts(runtime, "test-remote-user-base");
     let test_config = create_test_config();
     let temp_dir = create_test_devcontainer(
         "test-remote-user-base",
@@ -354,6 +356,168 @@ fn test_up_microsoft_devcontainer_base_resolves_remote_user() {
         remote_user, "vscode",
         "Expected _REMOTE_USER='vscode' (from devcontainer.metadata label) but got '{}'",
         remote_user
+    );
+
+    drop(temp_dir);
+}
+
+/// Regression test for the `devcon start` command always creating a new container.
+///
+/// `list()` calls `docker ps` (no `-a` flag), which only returns *running*
+/// containers.  When the container is stopped, `start_with_features` cannot
+/// find it and calls `docker run` again, spawning a duplicate container.
+/// The correct behaviour is to restart the existing stopped container and
+/// return its original ID.
+#[test]
+fn test_start_reuses_stopped_container() {
+    let runtime = get_runtime();
+    if !is_runtime_available(runtime) {
+        println!("Skipping test: {:?} runtime not available", runtime);
+        return;
+    }
+
+    let test_config = create_test_config();
+    cleanup_test_artifacts(runtime, "test-start-reuse");
+    let temp_dir = create_test_devcontainer(
+        "test-start-reuse",
+        "mcr.microsoft.com/devcontainers/base:ubuntu",
+        None,
+    );
+
+    // First `up` — build and start the container.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("--output")
+        .arg("json")
+        .arg("up")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute up command");
+    let output = result.unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Up command failed.\nStdout: {}\nStderr: {}",
+        stdout,
+        stderr
+    );
+
+    let up_json =
+        serde_json::from_str::<serde_json::Value>(&stdout).expect("up output is not valid JSON");
+    let container_id_after_up = up_json["container_id"]
+        .as_str()
+        .expect("up output JSON does not contain container_id")
+        .to_string();
+
+    // Stop the container so it is in an exited (not running) state.
+    stop_container(runtime, &container_id_after_up);
+
+    // `devcon start` — must restart the existing stopped container, not spawn a new one.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("--output")
+        .arg("json")
+        .arg("start")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute start command");
+    let output = result.unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Start command failed.\nStdout: {}\nStderr: {}",
+        stdout,
+        stderr
+    );
+
+    let start_json = serde_json::from_str::<serde_json::Value>(&stdout)
+        .expect("start output is not valid JSON");
+    let container_id_after_start = start_json["container_id"]
+        .as_str()
+        .expect("start output JSON does not contain container_id")
+        .to_string();
+
+    assert_eq!(
+        container_id_after_up, container_id_after_start,
+        "devcon start created a new container instead of restarting the existing stopped one"
+    );
+
+    drop(temp_dir);
+}
+
+/// Regression test for https://github.com/devconhq/devcon/issues/85.
+///
+/// Running `devcon up` a second time on an already-built image must reuse the
+/// cached image rather than rebuilding it from scratch.  If the image ID
+/// reported by the runtime changes between two consecutive `up` invocations
+/// (with no changes to the devcontainer configuration), the cache is broken.
+#[test]
+fn test_up_does_not_rebuild_existing_image() {
+    let runtime = get_runtime();
+    if !is_runtime_available(runtime) {
+        println!("Skipping test: {:?} runtime not available", runtime);
+        return;
+    }
+
+    let test_config = create_test_config();
+    cleanup_test_artifacts(runtime, "test-no-rebuild");
+    let temp_dir = create_test_devcontainer(
+        "test-no-rebuild",
+        "mcr.microsoft.com/devcontainers/base:ubuntu",
+        None,
+    );
+
+    // First `up` — builds and starts the container.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("up")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute first up command");
+    let output = result.unwrap();
+    assert!(
+        output.status.success(),
+        "First up command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let image_id_after_first_up = get_image_id(runtime, "devcon-test-no-rebuild:latest")
+        .expect("Image devcon-test-no-rebuild:latest not found after first up");
+
+    // Second `up` — must reuse the cached image, not rebuild it.
+    let mut cmd = cargo_bin_cmd!("devcon");
+    let result = cmd
+        .arg("--config")
+        .arg(&test_config)
+        .arg("up")
+        .arg(temp_dir.path().to_str().unwrap())
+        .output();
+
+    assert!(result.is_ok(), "Failed to execute second up command");
+    let output = result.unwrap();
+    assert!(
+        output.status.success(),
+        "Second up command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let image_id_after_second_up = get_image_id(runtime, "devcon-test-no-rebuild:latest")
+        .expect("Image devcon-test-no-rebuild:latest not found after second up");
+
+    assert_eq!(
+        image_id_after_first_up, image_id_after_second_up,
+        "Image was rebuilt on second 'devcon up' even though nothing changed (issue #85)"
     );
 
     drop(temp_dir);

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -178,6 +178,86 @@ pub fn extract_container_name(output: &str) -> Option<String> {
     None
 }
 
+/// Stop a running container
+#[allow(dead_code)]
+pub fn stop_container(runtime: Runtime, container_id: &str) {
+    let cmd = runtime_cmd(runtime);
+    let _ = Command::new(cmd)
+        .arg("stop")
+        .arg(container_id)
+        .output();
+}
+
+/// Remove all containers and images belonging to a devcon test project.
+///
+/// Stops and force-removes any containers labelled `devcon.project=<project_name>`,
+/// then removes all images whose repository matches `devcon-<project_name>`.
+/// Call this at the start of tests that create containers so stale state from
+/// previous runs does not interfere.
+#[allow(dead_code)]
+pub fn cleanup_test_artifacts(runtime: Runtime, project_name: &str) {
+    let cmd = runtime_cmd(runtime);
+    let label = format!("devcon.project={}", project_name);
+    let image_prefix = format!("devcon-{}", project_name);
+
+    match runtime {
+        Runtime::Docker => {
+            // Find all containers (running or stopped) for this project
+            let ps_output = Command::new(cmd)
+                .args(["ps", "-a", "--filter", &format!("label={}", label), "--format", "{{.ID}}"])
+                .output();
+            if let Ok(out) = ps_output {
+                let ids = String::from_utf8_lossy(&out.stdout);
+                for id in ids.lines().map(str::trim).filter(|s| !s.is_empty()) {
+                    let _ = Command::new(cmd).args(["rm", "-f", id]).output();
+                }
+            }
+
+            // Remove all images for this project (latest + any build-* tags)
+            let img_output = Command::new(cmd)
+                .args(["image", "ls", "--format", "{{.Repository}}:{{.Tag}}"])
+                .output();
+            if let Ok(out) = img_output {
+                let tags = String::from_utf8_lossy(&out.stdout);
+                for tag in tags.lines().map(str::trim).filter(|t| t.starts_with(&image_prefix)) {
+                    let _ = Command::new(cmd).args(["rmi", "-f", tag]).output();
+                }
+            }
+        }
+        Runtime::Apple => {
+            // Apple: list all containers and filter by name prefix
+            let ls_output = Command::new(cmd)
+                .args(["container", "list", "--all", "--format", "json"])
+                .output();
+            if let Ok(out) = ls_output
+                && let Ok(entries) = serde_json::from_slice::<Vec<serde_json::Value>>(&out.stdout)
+            {
+                for entry in entries {
+                    let name = entry["name"].as_str().unwrap_or("");
+                    // devcon container name is devcon.<project_name>
+                    if name == format!("devcon.{}", project_name) {
+                        let _ = Command::new(cmd).args(["container", "rm", "-f", name]).output();
+                    }
+                }
+            }
+            // Remove images
+            let img_output = Command::new(cmd).args(["image", "list", "--format", "json"]).output();
+            if let Ok(out) = img_output
+                && let Ok(entries) = serde_json::from_slice::<Vec<serde_json::Value>>(&out.stdout)
+            {
+                for entry in entries {
+                    let repo = entry["repository"].as_str().unwrap_or("");
+                    let tag = entry["tag"].as_str().unwrap_or("");
+                    let full = format!("{}:{}", repo, tag);
+                    if full.starts_with(&image_prefix) {
+                        let _ = Command::new(cmd).args(["image", "rm", "-f", &full]).output();
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Clean up a container by name
 #[allow(dead_code)]
 pub fn cleanup_container(runtime: Runtime, container_name: &str) {
@@ -231,6 +311,27 @@ pub fn exec_in_container(
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
         Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}
+
+/// Get the image ID for a given image tag, returns None if not found
+#[allow(dead_code)]
+pub fn get_image_id(runtime: Runtime, image_tag: &str) -> Option<String> {
+    let cmd = runtime_cmd(runtime);
+    let output = Command::new(cmd)
+        .arg("image")
+        .arg("inspect")
+        .arg(image_tag)
+        .arg("--format")
+        .arg("{{.Id}}")
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if id.is_empty() { None } else { Some(id) }
+    } else {
+        None
     }
 }
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -182,10 +182,7 @@ pub fn extract_container_name(output: &str) -> Option<String> {
 #[allow(dead_code)]
 pub fn stop_container(runtime: Runtime, container_id: &str) {
     let cmd = runtime_cmd(runtime);
-    let _ = Command::new(cmd)
-        .arg("stop")
-        .arg(container_id)
-        .output();
+    let _ = Command::new(cmd).arg("stop").arg(container_id).output();
 }
 
 /// Remove all containers and images belonging to a devcon test project.
@@ -204,7 +201,14 @@ pub fn cleanup_test_artifacts(runtime: Runtime, project_name: &str) {
         Runtime::Docker => {
             // Find all containers (running or stopped) for this project
             let ps_output = Command::new(cmd)
-                .args(["ps", "-a", "--filter", &format!("label={}", label), "--format", "{{.ID}}"])
+                .args([
+                    "ps",
+                    "-a",
+                    "--filter",
+                    &format!("label={}", label),
+                    "--format",
+                    "{{.ID}}",
+                ])
                 .output();
             if let Ok(out) = ps_output {
                 let ids = String::from_utf8_lossy(&out.stdout);
@@ -219,7 +223,11 @@ pub fn cleanup_test_artifacts(runtime: Runtime, project_name: &str) {
                 .output();
             if let Ok(out) = img_output {
                 let tags = String::from_utf8_lossy(&out.stdout);
-                for tag in tags.lines().map(str::trim).filter(|t| t.starts_with(&image_prefix)) {
+                for tag in tags
+                    .lines()
+                    .map(str::trim)
+                    .filter(|t| t.starts_with(&image_prefix))
+                {
                     let _ = Command::new(cmd).args(["rmi", "-f", tag]).output();
                 }
             }
@@ -236,12 +244,16 @@ pub fn cleanup_test_artifacts(runtime: Runtime, project_name: &str) {
                     let name = entry["name"].as_str().unwrap_or("");
                     // devcon container name is devcon.<project_name>
                     if name == format!("devcon.{}", project_name) {
-                        let _ = Command::new(cmd).args(["container", "rm", "-f", name]).output();
+                        let _ = Command::new(cmd)
+                            .args(["container", "rm", "-f", name])
+                            .output();
                     }
                 }
             }
             // Remove images
-            let img_output = Command::new(cmd).args(["image", "list", "--format", "json"]).output();
+            let img_output = Command::new(cmd)
+                .args(["image", "list", "--format", "json"])
+                .output();
             if let Ok(out) = img_output
                 && let Ok(entries) = serde_json::from_slice::<Vec<serde_json::Value>>(&out.stdout)
             {
@@ -250,7 +262,9 @@ pub fn cleanup_test_artifacts(runtime: Runtime, project_name: &str) {
                     let tag = entry["tag"].as_str().unwrap_or("");
                     let full = format!("{}:{}", repo, tag);
                     if full.starts_with(&image_prefix) {
-                        let _ = Command::new(cmd).args(["image", "rm", "-f", &full]).output();
+                        let _ = Command::new(cmd)
+                            .args(["image", "rm", "-f", &full])
+                            .output();
                     }
                 }
             }


### PR DESCRIPTION
Implement better container lifecycle:
- Do not rebuild container if contents havent changed
- Start a stopped container instead of recreating a new one


- **fix: do not rebuild container if already present / correct restarting of stopped container**
- **fix: implement hashing of devcontainer.json content in image label**
